### PR TITLE
Use C_AddOns API and update metadata

### DIFF
--- a/ClickMorph.lua
+++ b/ClickMorph.lua
@@ -79,11 +79,11 @@ end
 function CM:GetFileData(frame)
 	if not FileData then
 		local addon = "ClickMorphData"
-		local loaded, reason = LoadAddOn(addon)
+		local loaded, reason = C_AddOns.LoadAddOn(addon)
 		if not loaded then
 			if reason == "DISABLED" then
-				EnableAddOn(addon, true)
-				LoadAddOn(addon)
+				C_AddOns.EnableAddOn(addon, true)
+				C_AddOns.LoadAddOn(addon)
 			else
 				frame:SetScript("OnUpdate", nil) -- cancel any wardrobe timer
 				self:PrintChat("The ClickMorphData folder could not be found."

--- a/ClickMorph.toc
+++ b/ClickMorph.toc
@@ -1,5 +1,5 @@
 ## Interface: 120000, 50503, 20505, 11508
-## Version: 1.0.1
+## Version: 1.7.4
 ## Title: ClickMorph
 ## Notes: Lets you alt-click to morph
 ## Author: Ketho, Icesythe7, DarkLinux

--- a/Compat.lua
+++ b/Compat.lua
@@ -167,7 +167,7 @@ local shownAtlasLootMessage
 local SEC_BUTTON_COUNT = 0
 
 local function IsAtlasLootKeybind()
-	return IsAltKeyDown() and IsShiftKeyDown()
+	return if IsAltKeyDown()
 end
 
 local function HookAtlasLootButton(btn)

--- a/Data/ClickMorphData.toc
+++ b/Data/ClickMorphData.toc
@@ -1,6 +1,6 @@
-## Interface-Retail: 90005
-## Interface-Classic: 11307
-## Interface-BCC: 20501
+## Interface: 120000
+## Interface-Classic: 11508
+## Interface-BCC: 20505
 ## Title: ClickMorphData
 ## Author: Ketho
 ## Notes: Load on Demand FileData

--- a/Live/Wardrobe.lua
+++ b/Live/Wardrobe.lua
@@ -113,10 +113,6 @@ function f:InitWardrobe()
 
 		-- item sets
 		WardrobeCollectionFrame.SetsCollectionFrame.Model:HookScript("OnMouseUp", CM.MorphTransmogSet)
-		-- items
-		for _, model in pairs(ItemsCollection.Models) do
-			model:HookScript("OnMouseUp", CM.MorphTransmogItem)
-		end
 
 		ScanningModel = CreateFrame("DressUpModel")
 		ScanningModel:SetUnit("player")
@@ -155,7 +151,7 @@ function f:InitializeData()
 	end
 	db = ClickMorphDataDB
 
-	local version = GetAddOnMetadata("ClickMorph", "Version")
+	local version = C_AddOns.GetAddOnMetadata("ClickMorph", "Version")
 	if not db.SourceInfo then
 		CM:PrintChat(format("|cff71D5FFv%s|r Rebuilding data..", version))
 		db.SourceInfo, db.IllusionSourceInfo = self:QueryData()


### PR DESCRIPTION
Replace legacy global addon APIs with C_AddOns equivalents (LoadAddOn, EnableAddOn, GetAddOnMetadata). Bump ClickMorph version in the .toc and simplify ClickMorphData interface entries. Remove per-item model hooks in Live/Wardrobe to avoid iterating ItemsCollection.Models